### PR TITLE
use stdlib sha3_kekkak

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ openpyxl>=3.0.9
 pandas>=1.3.4
 py-algorand-sdk>=1.10.0
 pycodestyle>=2.8.0
-pysha3>=1.0.2
 python-dateutil>=2.8.2
 pytz>=2021.3
 PyYAML>=6.0

--- a/src/common/address.py
+++ b/src/common/address.py
@@ -1,6 +1,6 @@
 import bech32
 import logging
-import sha3
+import hashlib
 from typing import List, Optional
 
 
@@ -10,7 +10,7 @@ def _checksum_encode(address: List[int]):
     hex_addr = bytes(address).hex()
     checksummed_buffer = ""
 
-    k = sha3.keccak_256()
+    k = hashlib.sha3_256()
     k.update(hex_addr.encode("utf-8"))
     hashed_address = k.digest().hex()
 


### PR DESCRIPTION
## Problem description

This PR removes the sha3 dependency as it's not necessary [since 3.6](https://docs.python.org/3/library/hashlib.html#hash-algorithms). `sha3` doesn't build on 3.11 so it prevents us from upgrading.

## Required for SOC2 compliance

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
- [x] Automated tests covering modified code pass
