### PR TITLE
Automate publish to cloudsmith

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,4 +15,4 @@ jobs:
           repository_name: "cointracker"
           repository_url: "https://python.cloudsmith.io/cointracker/pypi/"
           repository_username: ${{ secrets.USERNAME }}
-          repository_password: ${{ secrets.API_KEY }} 
+          repository_password: ${{ secrets.API_KEY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,4 @@
+---
 name: Publish cointracker openspec lib
 on:
   push:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish to cointracker private Python package repository
@@ -14,5 +15,5 @@ jobs:
         with:
           repository_name: "cointracker"
           repository_url: "https://python.cloudsmith.io/cointracker/pypi/"
-          repository_username: ${{ secrets.USERNAME }}
-          repository_password: ${{ secrets.API_KEY }}
+          repository_username: ${{ secrets.CLOUDSMITH_USERNAME }}
+          repository_password: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,17 @@
+name: Publish cointracker openspec lib
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish to cointracker private Python package repository
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          repository_name: "cointracker"
+          repository_url: "https://python.cloudsmith.io/cointracker/pypi/"
+          repository_username: ${{ secrets.USERNAME }}
+          repository_password: ${{ secrets.API_KEY }} 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+name = "staketaxcsv"
+version = "0.0.2"
+description = ""
+authors = ["CoinTracker <eng@cointracker.io>"]


### PR DESCRIPTION
Add workflow that automates publishing the package to cloudsmith

It requires manually updating the package version.

I don't have access to the GitHub secrets so I can't add the Cloudsmith credentials to the repo :(