### PR TITLE
Change trigger branch name for github actions workflow from 'main' to 'module'

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish cointracker openspec lib
 on:
   push:
     branches:
-      - main
+      - module
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem description
I forgot that the main branch of this repo is called module


## Solution
switched the name of the branch from main to module


## Required for SOC2 compliance

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
- [ ] Automated tests covering modified code pass
