### PR TITLE
INT 1975 Fix a mapping for lunc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ project_packages = [source_package_regex.sub(PACKAGE_NAME, name) for name in sou
 
 setup(
     name=PACKAGE_NAME,
-    version='0.0.1',
+    version='0.0.3',
     install_requires=required,
     package_dir={PACKAGE_NAME: SOURCE_DIRECTORY},
     packages=project_packages,

--- a/src/luna1/api_lcd.py
+++ b/src/luna1/api_lcd.py
@@ -40,17 +40,17 @@ class LcdAPI:
         The two endpoints combined have the same data as what was previously returned by 
         the old endpoint, which is now deprecated
 
-        - new "msg" == old "init_msg"
-        - new "contract_info" == old "result"
+        - new ["contract_info"] == old ["result"]
+        - new ["msg"] == old ["result"]["init_msg"]
         - the first entry returned from contract history["entries"] contains the relevant data
 
         This is not originally part of the staketaxcsv package
         """
         data = CosmWasmLcdAPI(TERRA_LCD_NODE).contract_history(contract)
         contract_history = data["entries"][0]
-        contract_history["init_msg"] = contract_history["msg"]
         contract_data = CosmWasmLcdAPI(TERRA_LCD_NODE).contract(contract)
         contract_data["result"] = contract_data["contract_info"]
+        contract_data["result"]["init_msg"] = contract_history["msg"]
         contract_wasm = contract_data | contract_history
         return contract_wasm
 

--- a/src/luna1/tests/test_api_lcd.py
+++ b/src/luna1/tests/test_api_lcd.py
@@ -18,8 +18,7 @@ class APILCDTest(unittest.TestCase):
                 contract_wasm = LcdAPI.contract_info_from_cosmwasm("blah")
 
         assert contract_wasm ["code_id"] == "4"
-        assert contract_wasm["msg"] == contract_wasm["init_msg"]
-        assert contract_wasm["result"] == contract_wasm["contract_info"]
+        assert contract_wasm["result"]["init_msg"] == contract_wasm["msg"]
 
     def test_contract_info_from_cosmwasm(self):
         contract_history = _get_fixture_file_content("cosmwasm_contract_history.json")
@@ -33,25 +32,6 @@ class APILCDTest(unittest.TestCase):
             "block_height": "13215800",
             "tx_index": "0"
         }
-        assert contract_wasm["msg"] == {
-            "asset_infos": [
-            {
-                "token": {
-                "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
-                }
-            },
-            {
-                "native_token": {
-                "denom": "uluna"
-                }
-            }
-            ],
-            "init_hook": {
-                "contract_addr": "terra1ulgw0td86nvs4wtpsc80thv6xelk76ut7a7apj",
-                "msg": "eyJyZWdpc3RlciI6eyJhc3NldF9pbmZvcyI6W3sidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMWtjODdtdTQ2MGZ3a3F0ZTI5cnF1aDRoYzIwbTU0Znh3dHN4N2dwIn19LHsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoidWx1bmEifX1dfX0="
-            },
-            "token_code_id": 3
-        }
         assert contract_wasm["result"] == {
             "code_id": "7604",
             "creator": "terra1ulgw0td86nvs4wtpsc80thv6xelk76ut7a7apj",
@@ -61,6 +41,26 @@ class APILCDTest(unittest.TestCase):
                 "block_height": "13215800",
                 "tx_index": "0"
             },
-            "ibc_port_id": ""
+            "ibc_port_id": "",
+            "init_msg":
+                {
+                "asset_infos": [
+                {
+                    "token": {
+                    "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+                    }
+                },
+                {
+                    "native_token": {
+                    "denom": "uluna"
+                    }
+                }
+                ],
+                "init_hook": {
+                    "contract_addr": "terra1ulgw0td86nvs4wtpsc80thv6xelk76ut7a7apj",
+                    "msg": "eyJyZWdpc3RlciI6eyJhc3NldF9pbmZvcyI6W3sidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMWtjODdtdTQ2MGZ3a3F0ZTI5cnF1aDRoYzIwbTU0Znh3dHN4N2dwIn19LHsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoidWx1bmEifX1dfX0="
+                },
+                "token_code_id": 3
+            }
         }
 


### PR DESCRIPTION
## Problem description
In the parsing of what is returned from the terra classic LCD node, "init_msg" should be part of "result", but the mappings currently don't do that

## Background
Had to remap some of the API results for the terra classic LCD node in order to match the parsing for the previous API results

## Solution
updated the mapper function

## Future work

Once this is merged I will update the package version on cloudsmith and then update the package in my [other PR](https://github.com/coin-tracker/coin-tracker-server/pull/13628)


## Required for SOC2 compliance

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
- [ ] Automated tests covering modified code pass
