### PR TITLE
[INT-2508] Unable to import or sync wallets on Terra Classic (LUNC) blockchain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
 name = "staketaxcsv"
-version = "0.0.2"
+version = "0.0.4"
 description = ""
 authors = ["CoinTracker <eng@cointracker.io>"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ project_packages = [source_package_regex.sub(PACKAGE_NAME, name) for name in sou
 
 setup(
     name=PACKAGE_NAME,
-    version='0.0.3',
+    version='0.0.4',
     install_requires=required,
     package_dir={PACKAGE_NAME: SOURCE_DIRECTORY},
     packages=project_packages,

--- a/src/luna1/api_lcd.py
+++ b/src/luna1/api_lcd.py
@@ -22,9 +22,9 @@ class LcdAPI:
     @classmethod
     def contract_info(cls, contract):
         """Calls the LCD API for contract info for a given contract address.
-        
-        This function is called as part of the staketaxcsv transaction parsing process. 
-        The package code contains an API call to a now deprecated function, so the old 
+
+        This function is called as part of the staketaxcsv transaction parsing process.
+        The package code contains an API call to a now deprecated function, so the old
         code has been replaced with a function that calls two API endpoints that combine
         to return the same data as before
         """
@@ -32,12 +32,12 @@ class LcdAPI:
 
     @classmethod
     def contract_info_from_cosmwasm(cls, contract):
-        """Calls the contract info and contract history endpoints from CosmWasmLcdAPI 
-        and formats them in the way the old /wasm/contracts/{} endpoint returned data. 
-        This allows the staketaxcsv package to parse the data in the same way it parsed 
+        """Calls the contract info and contract history endpoints from CosmWasmLcdAPI
+        and formats them in the way the old /wasm/contracts/{} endpoint returned data.
+        This allows the staketaxcsv package to parse the data in the same way it parsed
         the old data without having to rewrite a ton of functions.
 
-        The two endpoints combined have the same data as what was previously returned by 
+        The two endpoints combined have the same data as what was previously returned by
         the old endpoint, which is now deprecated
 
         - new ["contract_info"] == old ["result"]
@@ -88,6 +88,10 @@ class LcdAPI:
     @classmethod
     def num_txs(cls, wallet_address):
         """Endpoint is deprecated"""
+        return 200
+
+        # TODO: Fix this function.  Changes to LCD api make this no longer work.
+
         data = cls._get_txs(wallet_address, EVENTS_TYPE_SENDER, 0, LIMIT_TX_QUERY, 0)
         num_send = int(data["pagination"]["total"])
 

--- a/src/luna1/api_lcd.py
+++ b/src/luna1/api_lcd.py
@@ -10,8 +10,8 @@ from urllib.parse import urlencode
 
 import requests
 from staketaxcsv.common.ibc.api_common import EVENTS_TYPE_RECIPIENT, EVENTS_TYPE_SENDER, EVENTS_TYPE_SIGNER
-from staketaxcsv.settings_csv import TERRA_LCD_NODE
 from staketaxcsv.common.ibc.api_lcd_cosmwasm import CosmWasmLcdAPI
+from staketaxcsv.settings_csv import TERRA_LCD_NODE
 
 LIMIT_TX_QUERY = 50
 


### PR DESCRIPTION
## Problem description
We use a fork of staketaxcsv for our LUNC integration. Syncs are failing with a key error due to the API response changing. The forked repo has made a fix but our fork does not have this fix.

## Background
Here is the commit for the fix from the main repo: https://github.com/hodgerpodger/staketaxcsv/commit/f99193017e4739f7c22f61890270913e57c74df8

I built an alpha version of our fork, 0.0.4a0, and tested it over on coin-tracker-server. The fix is working as expected and wallets are syncing successfully.

https://cloudsmith.io/~cointracker/repos/pypi/packages/detail/python/staketaxcsv/0.0.4a0/a=noarch;xf=bdist_wheel;xn=staketaxcsv;xv=py2.py3/

## Solution
- Apply commit with fix from the forked repo.

## Future work
I will build the release version, 0.0.4, when this PR has been approved.

## Screenshot
<img width="1920" alt="image" src="https://github.com/coin-tracker/staketaxcsv/assets/110897841/58edf348-eb5d-4d0e-8916-fb0a308a00e1">

## Required for SOC2 compliance

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
- [x] Automated tests covering modified code pass
