### PR TITLE
IS-1169: Add missing r prefix to string

### DIFF
--- a/src/common/ibc/MsgInfoIBC.py
+++ b/src/common/ibc/MsgInfoIBC.py
@@ -147,7 +147,7 @@ class MsgInfoIBC:
                 continue
 
             # Split into (amount_raw, currency_raw)
-            m = re.search('^(\d+)(.*)', amt_string)
+            m = re.search(r'^(\d+)(.*)', amt_string)
             if not m:
                 raise Exception("Unexpected amt_string: {}".format(amt_string))
             amount_raw, currency_raw = m.group(1), m.group(2)


### PR DESCRIPTION
## Problem description

This PR fixes a SyntaxWarning we're seeing on 3.12

```
  warnings.warn(
/Users/pablo/Development/coin-tracker-server/.venv/lib/python3.12/site-packages/staketaxcsv/common/ibc/MsgInfoIBC.py:150: SyntaxWarning: invalid escape sequence '\d'
  m = re.search('^(\d+)(.*)', amt_string)
```

## Required for SOC2 compliance

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
- [x] Automated tests covering modified code pass
